### PR TITLE
Correct invalid variable access

### DIFF
--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -197,14 +197,14 @@ var TaggedInput = React.createClass({
           s.tags.push(tagText.trim());
           self.setState({currentInput: ''});
           if (p.onAddTag) {
-            p.onAddTag(enteredValue);
+            p.onAddTag(tagText);
           }
         }
       } else {
         s.tags.push(tagText.trim());
         self.setState({currentInput: ''});
         if (p.onAddTag) {
-          p.onAddTag(enteredValue);
+          p.onAddTag(tagText);
         }
       }
     }


### PR DESCRIPTION
`onAddTag` handler is not being invoked correctly because a variable is being referenced that was not defined in current scope.
