### PR TITLE
Compatibility with Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/tutorialhorizon/react-tagged-input.git"
   },
+  "browserify": {
+    "transform": ["reactify"]
+  },
   "dependencies": {
     "react": "^0.12.1"
   },


### PR DESCRIPTION
Added reactify as browserify transform

This is required to perform the jsx transform when using the module as a npm module