### PR TITLE
Browserify compatibility, dependency improvements, delimiters and tagOnBlur props

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ React.render(
     onEnter={/*function*/}
     onAddTag={/*function*/} // argument - tag that was added
     onRemoveTag={/*function*/} // argument - tag that got removed
+    tagOnBlur={false}          // If true, creates a tag from any text entered when input box loses focus
     unique={true} // Whether duplicate entries are allowed
     classes={'my-css-namespace'}
     removeTagLabel={"\u274C"} // Unicode of a symbol or an Object click to delete tags. Defaults to 'x'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ npm install react-tagged-input
 
 To make give this component a proper look and feel, you will want to include the [these styles](https://github.com/tutorialhorizon/react-tagged-input/blob/master/examples/index.css) and namespace them appropriately using the `classes` property as shown below to customize them as per your liking.
 
-Space and comma act as the default delimiters for when the user types.
+Space and comma act as the default delimiters for when the user types.  Customise this with the `delimiters` 
+prop, which should be set to an array of 1 character strings.
 
 ```js
 var React = require('react'),

--- a/css/react-tagged-input.css
+++ b/css/react-tagged-input.css
@@ -1,0 +1,45 @@
+.tagged-input-wrapper {
+  border-width: 1px;
+  border-style: solid;
+  border-color: #dadada;
+  padding: 2px;
+}
+
+.tagged-input-wrapper .tagged-input {
+  border: none;
+  outline: none;
+}
+
+.tagged-input-wrapper .tag .tag-text {
+  padding-left: 5px;
+}
+
+.tagged-input-wrapper .tag {
+  display: inline-block;
+  background-color: #E9E9E9;
+  padding: 2px 0px 2px 2px;
+  border-radius: 2px;
+  margin-left: 2px;
+  margin-right: 2px;
+}
+
+.tagged-input-wrapper .tag.duplicate {
+  background: #FFDB7B;
+}
+
+.tagged-input-wrapper .tag .remove {
+  color: #a0a0a0;
+  padding: 0px 4px;
+  font-size: 75%;
+  line-height: 100%;
+  cursor: pointer;
+}
+
+.tagged-input-wrapper .tag .remove:hover {
+  color: red;
+}
+
+.tagged-input-wrapper .tag .remove,
+.tagged-input-wrapper .tag .tag-text {
+  display: inline-block;
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/tutorialhorizon/react-tagged-input.git"
   },
+  "browserify": {
+    "transform": ["reactify"]
+  },
   "dependencies": {
     "react": "^0.12.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "browserify": {
     "transform": ["reactify"]
   },
-  "dependencies": {
-    "react": "^0.12.1"
+  "peerDependencies": {
+    "react": ">=0.12.1 <0.13"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -30,6 +30,7 @@
     "grunt-react": "^0.9.0",
     "grunt-webpack": "^1.0.8",
     "jsx-loader": "^0.12.2",
+    "react": ">=0.12.1 <0.13",
     "webpack": "^1.4.13",
     "webpack-dev-server": "^1.6.6"
   }

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -41,12 +41,14 @@ var TaggedInput = React.createClass({
       if (typeof props[propName] !== 'string' || props[propName].length !== 1) {
         return new Error('TaggedInput prop delimiters must be an array of 1 character strings')
       }
-    })
+    }),
+    tagOnBlur: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
     return {
-      delimiters: [' ', ',']
+      delimiters: [' ', ','],
+      tagOnBlur: false
     }
 
   },
@@ -98,6 +100,7 @@ var TaggedInput = React.createClass({
         onKeyUp={this._handleKeyUp}
         onKeyDown={this._handleKeyDown}
         onChange={this._handleChange}
+        onBlur={this._handleBlur}
         value={s.currentInput}
         placeholder={placeholder}>
       </input>
@@ -196,6 +199,15 @@ var TaggedInput = React.createClass({
       this.setState({
         currentInput: e.target.value
       });
+    }
+  },
+
+  _handleBlur: function (e) {
+    if (this.props.tagOnBlur) {
+      var value = e.target.value;
+      if (value) {
+        this._validateAndTag(value)
+      }
     }
   },
 

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -69,6 +69,7 @@ var TaggedInput = React.createClass({
     for (i = 0; i < s.tags.length; i++) {
       tagComponents.push(
         <TagComponent
+          key={'tag' + i}
           item={s.tags[i]}
           key={s.tags[i]}
           itemIndex={i}

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -5,7 +5,6 @@
 var React = require('react');
 var joinClasses = require('react/lib/joinClasses');
 
-var delimiters = [' ', ','];
 
 var KEY_CODES = {
   ENTER: 13,
@@ -37,7 +36,19 @@ var TaggedInput = React.createClass({
     autofocus: React.PropTypes.bool,
     backspaceDeletesWord: React.PropTypes.bool,
     placeholder: React.PropTypes.string,
-    removeTagLabel: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object])
+    removeTagLabel: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
+    delimiters: React.PropTypes.arrayOf(function (props, propName, componentName) {
+      if (typeof props[propName] !== 'string' || props[propName].length !== 1) {
+        return new Error('TaggedInput prop delimiters must be an array of 1 character strings')
+      }
+    })
+  },
+
+  getDefaultProps: function () {
+    return {
+      delimiters: [' ', ',']
+    }
+
   },
 
   getInitialState: function () {
@@ -179,7 +190,7 @@ var TaggedInput = React.createClass({
       lastChar = value.charAt(value.length - 1),
       tagText = value.substring(0, value.length - 1);
 
-    if (delimiters.indexOf(lastChar) !== -1) {
+    if (this.props.delimiters.indexOf(lastChar) !== -1) {
       self._validateAndTag(tagText);
     } else {
       this.setState({


### PR DESCRIPTION
This is a combined pull request for several very small changes. 

1. Adds compatibility with browserify
2. Adds the default css under a fixed "css" directory (rather than a client having to include the file from examples)
3. Moves react to be a [peerDependency](http://blog.nodejs.org/2013/02/07/peer-dependencies/) (>=0.12.1 <0.13)
4. Adds key property to TagComponents
5. delimiters as prop, so they are customisable
6. tagOnBlur prop, so if the user enters text, then tags away, a tag is automatically created (when prop is true)