### PR TITLE
Implement editing a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ React.render(
     onAddTag={/*function*/} // argument - tag that was added
     onRemoveTag={/*function*/} // argument - tag that got removed
     tagOnBlur={false}          // If true, creates a tag from any text entered when input box loses focus
-    editTags={false}          // If true, enables tag editing by clicking the tag text
+    clickTagToEdit={false}          // If true, enables tag editing by clicking the tag text
     unique={true} // Whether duplicate entries are allowed
     classes={'my-css-namespace'}
     removeTagLabel={"\u274C"} // Unicode of a symbol or an Object click to delete tags. Defaults to 'x'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ React.render(
     onAddTag={/*function*/} // argument - tag that was added
     onRemoveTag={/*function*/} // argument - tag that got removed
     tagOnBlur={false}          // If true, creates a tag from any text entered when input box loses focus
+    editTags={false}          // If true, enables tag editing by clicking the tag text
     unique={true} // Whether duplicate entries are allowed
     classes={'my-css-namespace'}
     removeTagLabel={"\u274C"} // Unicode of a symbol or an Object click to delete tags. Defaults to 'x'

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -21,7 +21,7 @@ var DefaultTagComponent = React.createClass({
           {p.removeTagLabel}
         </div>
       </div>
-    );
+      );
   }
 
 });
@@ -41,9 +41,9 @@ var TaggedInput = React.createClass({
         return new Error('TaggedInput prop delimiters must be an array of 1 character strings')
       }
     }),
-    tagOnBlur: React.PropTypes.bool,  
+    tagOnBlur: React.PropTypes.bool,
     tabIndex: React.PropTypes.number,
-    editTags: React.PropTypes.bool
+    clickTagToEdit: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -53,7 +53,7 @@ var TaggedInput = React.createClass({
       autofocus: false,
       backspaceDeletesWord: true,
       tagOnBlur: false,
-      editTags: false
+      clickTagToEdit: false
     };
   },
 
@@ -86,38 +86,38 @@ var TaggedInput = React.createClass({
     for (i = 0; i < s.tags.length; i++) {
       tagComponents.push(
         <TagComponent
-          key={'tag' + i}
-          item={s.tags[i]}
-          key={s.tags[i]}
-          itemIndex={i}
-          onRemove={self._handleRemoveTag.bind(this, i)}
-          onEdit={p.editTags ? self._handleEditTag.bind(this, i) : null}
-          classes={p.unique && (i === s.duplicateIndex) ? 'duplicate' : ''}
-          removeTagLabel={p.removeTagLabel || "\u274C"}
+        key={'tag' + i}
+        item={s.tags[i]}
+        key={s.tags[i]}
+        itemIndex={i}
+        onRemove={self._handleRemoveTag.bind(this, i)}
+        onEdit={p.clickTagToEdit ? self._handleEditTag.bind(this, i) : null}
+        classes={p.unique && (i === s.duplicateIndex) ? 'duplicate' : ''}
+        removeTagLabel={p.removeTagLabel || "\u274C"}
         />
       );
     }
 
     var input = (
       <input type="text"
-        className="tagged-input"
-        ref="input"
-        onKeyUp={this._handleKeyUp}
-        onKeyDown={this._handleKeyDown}
-        onChange={this._handleChange}
-        onBlur={this._handleBlur}
-        value={s.currentInput}
-        placeholder={placeholder}
-        tabIndex={p.tabIndex}>
+      className="tagged-input"
+      ref="input"
+      onKeyUp={this._handleKeyUp}
+      onKeyDown={this._handleKeyDown}
+      onChange={this._handleChange}
+      onBlur={this._handleBlur}
+      value={s.currentInput}
+      placeholder={placeholder}
+      tabIndex={p.tabIndex}>
       </input>
-    );
+      );
 
     return (
       <div className={classes} onClick={self._handleClickOnWrapper}>
         {tagComponents}
         {input}
       </div>
-    );
+      );
   },
 
   componentDidMount: function () {
@@ -150,8 +150,13 @@ var TaggedInput = React.createClass({
   _handleEditTag: function (index) {
     var self = this, s = self.state, p = self.props;
 
+    if (s.currentInput) {
+      var trimmedInput = s.currentInput.trim();
+      if (trimmedInput && (this.state.tags.indexOf(trimmedInput) < 0 || !s.unique)) {
+        this._validateAndTag(s.currentInput);
+      }
+    }
     var removedItems = s.tags.splice(index, 1);
-
     if (s.duplicateIndex) {
       self.setState({duplicateIndex: null, currentInput: removedItems[0]}, function () {
         if (p.onRemoveTag) {

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -42,7 +42,8 @@ var TaggedInput = React.createClass({
       }
     }),
     tagOnBlur: React.PropTypes.bool,  
-    tabIndex: React.PropTypes.number
+    tabIndex: React.PropTypes.number,
+    editTags: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -51,7 +52,8 @@ var TaggedInput = React.createClass({
       unique: true,
       autofocus: false,
       backspaceDeletesWord: true,
-      tagOnBlur: false
+      tagOnBlur: false,
+      editTags: false
     };
   },
 
@@ -89,7 +91,7 @@ var TaggedInput = React.createClass({
           key={s.tags[i]}
           itemIndex={i}
           onRemove={self._handleRemoveTag.bind(this, i)}
-          onEdit={self._handleEditTag.bind(this, i)}
+          onEdit={p.editTags ? self._handleEditTag.bind(this, i) : null}
           classes={p.unique && (i === s.duplicateIndex) ? 'duplicate' : ''}
           removeTagLabel={p.removeTagLabel || "\u274C"}
         />

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -16,7 +16,7 @@ var DefaultTagComponent = React.createClass({
 
     return (
       <div className={joinClasses("tag", p.classes)}>
-        <div className="tag-text">{p.item}</div>
+        <div className="tag-text" onClick={p.onEdit}>{p.item}</div>
         <div className="remove" onClick={p.onRemove}>
           {p.removeTagLabel}
         </div>
@@ -41,7 +41,7 @@ var TaggedInput = React.createClass({
         return new Error('TaggedInput prop delimiters must be an array of 1 character strings')
       }
     }),
-    tagOnBlur: React.PropTypes.bool,	
+    tagOnBlur: React.PropTypes.bool,  
     tabIndex: React.PropTypes.number
   },
 
@@ -89,6 +89,7 @@ var TaggedInput = React.createClass({
           key={s.tags[i]}
           itemIndex={i}
           onRemove={self._handleRemoveTag.bind(this, i)}
+          onEdit={self._handleEditTag.bind(this, i)}
           classes={p.unique && (i === s.duplicateIndex) ? 'duplicate' : ''}
           removeTagLabel={p.removeTagLabel || "\u274C"}
         />
@@ -129,7 +130,6 @@ var TaggedInput = React.createClass({
     var self = this, s = self.state, p = self.props;
 
     var removedItems = s.tags.splice(index, 1);
-    var duplicateIndex;
 
     if (s.duplicateIndex) {
       self.setState({duplicateIndex: null}, function () {
@@ -142,6 +142,26 @@ var TaggedInput = React.createClass({
         p.onRemoveTag(removedItems[0]);
       }
       self.forceUpdate();
+    }
+  },
+
+  _handleEditTag: function (index) {
+    var self = this, s = self.state, p = self.props;
+
+    var removedItems = s.tags.splice(index, 1);
+
+    if (s.duplicateIndex) {
+      self.setState({duplicateIndex: null, currentInput: removedItems[0]}, function () {
+        if (p.onRemoveTag) {
+          p.onRemoveTag(removedItems[0]);
+        }
+      });
+    } else {
+    self.setState({currentInput: removedItems[0]}, function () {
+      if (p.onRemoveTag) {
+        p.onRemoveTag(removedItems[0]);
+      }
+    });
     }
   },
 

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -157,11 +157,11 @@ var TaggedInput = React.createClass({
         }
       });
     } else {
-    self.setState({currentInput: removedItems[0]}, function () {
-      if (p.onRemoveTag) {
-        p.onRemoveTag(removedItems[0]);
-      }
-    });
+      self.setState({currentInput: removedItems[0]}, function () {
+        if (p.onRemoveTag) {
+          p.onRemoveTag(removedItems[0]);
+        }
+      });
     }
   },
 


### PR DESCRIPTION
Previously it was impossible to edit a tag that was not the last one added and you had to delete a tag and type it again. With this change you can click the tag you want to edit and it will be deleted for the moment and the input value will be set to that tag which will allow you to change it (works especially well when tagOnBlur is enabled).