### PR TITLE
Add onBeforeAddTag and onBeforeRemoveTag events

### DIFF
--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -57,7 +57,7 @@ var TaggedInput = React.createClass({
       onBeforeAddTag: function (tag) {
         return true;
       },
-      onBeforeRemoveTag: function (tag) {
+      onBeforeRemoveTag: function (index) {
         return true;
       }
     };

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -142,20 +142,22 @@ var TaggedInput = React.createClass({
   _handleRemoveTag: function (index) {
     var self = this, s = self.state, p = self.props;
 
-    var removedItems = s.tags.splice(index, 1);
-    var duplicateIndex;
+    if (p.onBeforeRemoveTag(index)) {
+      var removedItems = s.tags.splice(index, 1);
+      var duplicateIndex;
 
-    if (s.duplicateIndex) {
-      self.setState({duplicateIndex: null}, function () {
+      if (s.duplicateIndex) {
+        self.setState({duplicateIndex: null}, function () {
+          if (p.onRemoveTag) {
+            p.onRemoveTag(removedItems[0]);
+          }
+        });
+      } else {
         if (p.onRemoveTag) {
           p.onRemoveTag(removedItems[0]);
         }
-      });
-    } else {
-      if (p.onRemoveTag) {
-        p.onRemoveTag(removedItems[0]);
+        self.forceUpdate();
       }
-      self.forceUpdate();
     }
   },
 
@@ -243,7 +245,9 @@ var TaggedInput = React.createClass({
         duplicateIndex = this.state.tags.indexOf(trimmedText);
 
         if (duplicateIndex === -1) {
-          s.tags.push(trimmedText);
+          if (p.onBeforeAddTag(trimmedText)) {
+            s.tags.push(trimmedText);
+          }
           self.setState({
             currentInput: '',
             duplicateIndex: null
@@ -263,7 +267,9 @@ var TaggedInput = React.createClass({
           });
         }
       } else {
-        s.tags.push(trimmedText);
+        if (p.onBeforeAddTag(trimmedText)) {
+          s.tags.push(trimmedText);
+        }
         self.setState({currentInput: ''}, function () {
           if (p.onAddTag) {
             p.onAddTag(tagText);

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -28,7 +28,9 @@ var DefaultTagComponent = React.createClass({
 
 var TaggedInput = React.createClass({
   propTypes: {
+    onBeforeAddTag: React.PropTypes.func,
     onAddTag: React.PropTypes.func,
+    onBeforeRemoveTag: React.PropTypes.func,
     onRemoveTag: React.PropTypes.func,
     onEnter: React.PropTypes.func,
     unique: React.PropTypes.bool,
@@ -51,7 +53,13 @@ var TaggedInput = React.createClass({
       unique: true,
       autofocus: false,
       backspaceDeletesWord: true,
-      tagOnBlur: false
+      tagOnBlur: false,
+      onBeforeAddTag: function (tag) {
+        return true;
+      },
+      onBeforeRemoveTag: function (tag) {
+        return true;
+      }
     };
   },
 

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -133,6 +133,12 @@ var TaggedInput = React.createClass({
     }
   },
 
+  componentWillReceiveProps: function (nextProps) {
+    this.setState({
+      tags: nextProps.tags
+    })
+  },
+
   _handleRemoveTag: function (index) {
     var self = this, s = self.state, p = self.props;
 

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -189,16 +189,18 @@ var TaggedInput = React.createClass({
     switch (e.keyCode) {
       case KEY_CODES.BACKSPACE:
         if (!e.target.value || e.target.value.length < 0) {
-          poppedValue = s.tags.pop();
+          if (p.onBeforeRemoveTag(s.tags.length - 1)) {
+            poppedValue = s.tags.pop();
 
-          newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
+            newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
 
-          this.setState({
-            currentInput: newCurrentInput,
-            duplicateIndex: null
-          });
-          if (p.onRemoveTag && poppedValue) {
-            p.onRemoveTag(poppedValue);
+            this.setState({
+              currentInput: newCurrentInput,
+              duplicateIndex: null
+            });
+            if (p.onRemoveTag && poppedValue) {
+              p.onRemoveTag(poppedValue);
+            }
           }
         }
         break;


### PR DESCRIPTION
### Why? 
In a nutshell; flux-compatibility.
My use-case (and possibly many others); I need to be able to add and remove tags by firing custom built actions which pass through the dispatcher, update a store and then propagate the changes back down to the component.

By adding two new events, `onBeforeAddTag` and `onBeforeRemoveTag`, this allows the user to break free of the normal execution pattern of updating the component state and we can then feed new tags to the plugin via the `componentWillReceiveProps` method - completing the flux component lifecycle pattern.

This does not affect normal (non-flux based) usage of the plugin, but essentially widens the potential adoption of the plugin.
