### PR TITLE
Slice to clone tags to prevent mutation

### DIFF
--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -37,6 +37,7 @@ var TaggedInput = React.createClass({
     autofocus: React.PropTypes.bool,
     backspaceDeletesWord: React.PropTypes.bool,
     placeholder: React.PropTypes.string,
+    tags: React.PropTypes.arrayOf(React.PropTypes.any),
     removeTagLabel: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
     delimiters: React.PropTypes.arrayOf(function (props, propName, componentName) {
       if (typeof props[propName] !== 'string' || props[propName].length !== 1) {
@@ -67,7 +68,7 @@ var TaggedInput = React.createClass({
 
   getInitialState: function () {
     return {
-      tags: this.props.tags || [],
+      tags: (this.props.tags || []).slice(0),
       currentInput: null
     };
   },


### PR DESCRIPTION
Use `propTypes` to enforce that `tags` prop is an array and use `.slice(0)` to make a copy of the array provided to prevent mutation of the original array.

This should fix issue #22