### PR TITLE
Update package.json to remove warnings on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "author": "Tutorialhorizon team",
   "version": "0.0.13",
   "description": "A custom input field to enter tags",
+  "license": "MIT",
   "scripts": {},
   "main": "./src/TaggedInput.jsx",
   "keywords": [
@@ -18,7 +19,9 @@
     "url": "https://github.com/tutorialhorizon/react-tagged-input.git"
   },
   "browserify": {
-    "transform": ["reactify"]
+    "transform": [
+      "reactify"
+    ]
   },
   "peerDependencies": {
     "react": ">=0.12.1 <0.14"
@@ -30,6 +33,7 @@
     "grunt-react": "^0.9.0",
     "grunt-webpack": "^1.0.8",
     "jsx-loader": "^0.12.2",
+    "node-libs-browser": "^0.5.2",
     "react": ">=0.12.1 <0.14",
     "webpack": "^1.4.13",
     "webpack-dev-server": "^1.6.6"


### PR DESCRIPTION
Add license and peer-dependency to prevent warnings on install.

```
$ npm -v
2.12.0
```

---

#### License warning
```
$ npm install
npm WARN package.json react-tagged-input@0.0.13 No license field.
```

#### Peer-dependency warnings
```
$ npm install
npm WARN peerDependencies The peer dependency node-libs-browser@>= 0.4.0 <=0.6.0 included from webpack will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```