### PR TITLE
Prevent `onAddTag` if `onBeforeAddTag` returns false

### DIFF
--- a/dist/TaggedInput.js
+++ b/dist/TaggedInput.js
@@ -144,21 +144,23 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
   _handleRemoveTag: function (index) {
     var self = this, s = self.state, p = self.props;
 
-    if (p.onBeforeRemoveTag(index)) {
-      var removedItems = s.tags.splice(index, 1);
+    if (!p.onBeforeRemoveTag(index)) {
+      return;
+    }
 
-      if (s.duplicateIndex) {
-        self.setState({duplicateIndex: null}, function () {
-          if (p.onRemoveTag) {
-            p.onRemoveTag(removedItems[0]);
-          }
-        });
-      } else {
+    var removedItems = s.tags.splice(index, 1);
+
+    if (s.duplicateIndex) {
+      self.setState({duplicateIndex: null}, function () {
         if (p.onRemoveTag) {
           p.onRemoveTag(removedItems[0]);
         }
-        self.forceUpdate();
+      });
+    } else {
+      if (p.onRemoveTag) {
+        p.onRemoveTag(removedItems[0]);
       }
+      self.forceUpdate();
     }
   },
 
@@ -215,18 +217,20 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
     switch (e.keyCode) {
       case KEY_CODES.BACKSPACE:
         if (!e.target.value || e.target.value.length < 0) {
-          if (p.onBeforeRemoveTag(s.tags.length - 1)) {
-            poppedValue = s.tags.pop();
+          if (!p.onBeforeRemoveTag(s.tags.length - 1)) {
+            return;
+          }
 
-            newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
+          poppedValue = s.tags.pop();
 
-            this.setState({
-              currentInput: newCurrentInput,
-              duplicateIndex: null
-            });
-            if (p.onRemoveTag && poppedValue) {
-              p.onRemoveTag(poppedValue);
-            }
+          newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
+
+          this.setState({
+            currentInput: newCurrentInput,
+            duplicateIndex: null
+          });
+          if (p.onRemoveTag && poppedValue) {
+            p.onRemoveTag(poppedValue);
           }
         }
         break;
@@ -279,9 +283,11 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
         }
 
         if (duplicateIndex === -1) {
-          if (p.onBeforeAddTag(trimmedText)) {
-            s.tags.push(trimmedText);
+          if (!p.onBeforeAddTag(trimmedText)) {
+            return;
           }
+
+          s.tags.push(trimmedText);
           self.setState({
             currentInput: '',
             duplicateIndex: null
@@ -301,9 +307,11 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
           });
         }
       } else {
-        if (p.onBeforeAddTag(trimmedText)) {
-          s.tags.push(trimmedText);
+        if (!p.onBeforeAddTag(trimmedText)) {
+          return;
         }
+
+        s.tags.push(trimmedText);
         self.setState({currentInput: ''}, function () {
           if (p.onAddTag) {
             p.onAddTag(tagText);

--- a/dist/TaggedInput.js
+++ b/dist/TaggedInput.js
@@ -144,23 +144,21 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
   _handleRemoveTag: function (index) {
     var self = this, s = self.state, p = self.props;
 
-    if (!p.onBeforeRemoveTag(index)) {
-      return;
-    }
+    if (p.onBeforeRemoveTag(index)) {
+      var removedItems = s.tags.splice(index, 1);
 
-    var removedItems = s.tags.splice(index, 1);
-
-    if (s.duplicateIndex) {
-      self.setState({duplicateIndex: null}, function () {
+      if (s.duplicateIndex) {
+        self.setState({duplicateIndex: null}, function () {
+          if (p.onRemoveTag) {
+            p.onRemoveTag(removedItems[0]);
+          }
+        });
+      } else {
         if (p.onRemoveTag) {
           p.onRemoveTag(removedItems[0]);
         }
-      });
-    } else {
-      if (p.onRemoveTag) {
-        p.onRemoveTag(removedItems[0]);
+        self.forceUpdate();
       }
-      self.forceUpdate();
     }
   },
 
@@ -217,20 +215,18 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
     switch (e.keyCode) {
       case KEY_CODES.BACKSPACE:
         if (!e.target.value || e.target.value.length < 0) {
-          if (!p.onBeforeRemoveTag(s.tags.length - 1)) {
-            return;
-          }
+          if (p.onBeforeRemoveTag(s.tags.length - 1)) {
+            poppedValue = s.tags.pop();
 
-          poppedValue = s.tags.pop();
+            newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
 
-          newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
-
-          this.setState({
-            currentInput: newCurrentInput,
-            duplicateIndex: null
-          });
-          if (p.onRemoveTag && poppedValue) {
-            p.onRemoveTag(poppedValue);
+            this.setState({
+              currentInput: newCurrentInput,
+              duplicateIndex: null
+            });
+            if (p.onRemoveTag && poppedValue) {
+              p.onRemoveTag(poppedValue);
+            }
           }
         }
         break;

--- a/examples/index.jsx
+++ b/examples/index.jsx
@@ -6,16 +6,16 @@ var React = require('react'),
   TaggedInput = require('../dist/TaggedInput.js'),
   mountPoint = document.querySelector('body');
 
-function tagAdded (tag) {
-  console.log(tag);
-}
-
 React.render(
   <TaggedInput
     autofocus={true}
     backspaceDeletesWord={true}
     placeholder={'Name some fruits'}
-    onAddTag={tagAdded}
     unique={true}
+    onBeforeAddTag={function() { return true; }}
+    onAddTag={function() { console.log('Tag added', arguments); }}
+    onBeforeRemoveTag={function() { return false; }}
+    onRemoveTag={function() { console.log('Tag removed', arguments); }}
+    tags={['one', 'two', 'three']}
   />,
 mountPoint );

--- a/examples/index.jsx
+++ b/examples/index.jsx
@@ -14,7 +14,7 @@ React.render(
     unique={true}
     onBeforeAddTag={function() { return true; }}
     onAddTag={function() { console.log('Tag added', arguments); }}
-    onBeforeRemoveTag={function() { return false; }}
+    onBeforeRemoveTag={function() { return true; }}
     onRemoveTag={function() { console.log('Tag removed', arguments); }}
     tags={['one', 'two', 'three']}
   />,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-tagged-input",
   "author": "Tutorialhorizon team",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A custom input field to enter tags",
   "license": "MIT",
   "scripts": {

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -144,23 +144,21 @@ var TaggedInput = React.createClass({
   _handleRemoveTag: function (index) {
     var self = this, s = self.state, p = self.props;
 
-    if (!p.onBeforeRemoveTag(index)) {
-      return;
-    }
+    if (p.onBeforeRemoveTag(index)) {
+      var removedItems = s.tags.splice(index, 1);
 
-    var removedItems = s.tags.splice(index, 1);
-
-    if (s.duplicateIndex) {
-      self.setState({duplicateIndex: null}, function () {
+      if (s.duplicateIndex) {
+        self.setState({duplicateIndex: null}, function () {
+          if (p.onRemoveTag) {
+            p.onRemoveTag(removedItems[0]);
+          }
+        });
+      } else {
         if (p.onRemoveTag) {
           p.onRemoveTag(removedItems[0]);
         }
-      });
-    } else {
-      if (p.onRemoveTag) {
-        p.onRemoveTag(removedItems[0]);
+        self.forceUpdate();
       }
-      self.forceUpdate();
     }
   },
 
@@ -217,20 +215,18 @@ var TaggedInput = React.createClass({
     switch (e.keyCode) {
       case KEY_CODES.BACKSPACE:
         if (!e.target.value || e.target.value.length < 0) {
-          if (!p.onBeforeRemoveTag(s.tags.length - 1)) {
-            return;
-          }
+          if (p.onBeforeRemoveTag(s.tags.length - 1)) {
+            poppedValue = s.tags.pop();
 
-          poppedValue = s.tags.pop();
+            newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
 
-          newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
-
-          this.setState({
-            currentInput: newCurrentInput,
-            duplicateIndex: null
-          });
-          if (p.onRemoveTag && poppedValue) {
-            p.onRemoveTag(poppedValue);
+            this.setState({
+              currentInput: newCurrentInput,
+              duplicateIndex: null
+            });
+            if (p.onRemoveTag && poppedValue) {
+              p.onRemoveTag(poppedValue);
+            }
           }
         }
         break;

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -144,21 +144,23 @@ var TaggedInput = React.createClass({
   _handleRemoveTag: function (index) {
     var self = this, s = self.state, p = self.props;
 
-    if (p.onBeforeRemoveTag(index)) {
-      var removedItems = s.tags.splice(index, 1);
+    if (!p.onBeforeRemoveTag(index)) {
+      return;
+    }
 
-      if (s.duplicateIndex) {
-        self.setState({duplicateIndex: null}, function () {
-          if (p.onRemoveTag) {
-            p.onRemoveTag(removedItems[0]);
-          }
-        });
-      } else {
+    var removedItems = s.tags.splice(index, 1);
+
+    if (s.duplicateIndex) {
+      self.setState({duplicateIndex: null}, function () {
         if (p.onRemoveTag) {
           p.onRemoveTag(removedItems[0]);
         }
-        self.forceUpdate();
+      });
+    } else {
+      if (p.onRemoveTag) {
+        p.onRemoveTag(removedItems[0]);
       }
+      self.forceUpdate();
     }
   },
 
@@ -215,18 +217,20 @@ var TaggedInput = React.createClass({
     switch (e.keyCode) {
       case KEY_CODES.BACKSPACE:
         if (!e.target.value || e.target.value.length < 0) {
-          if (p.onBeforeRemoveTag(s.tags.length - 1)) {
-            poppedValue = s.tags.pop();
+          if (!p.onBeforeRemoveTag(s.tags.length - 1)) {
+            return;
+          }
 
-            newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
+          poppedValue = s.tags.pop();
 
-            this.setState({
-              currentInput: newCurrentInput,
-              duplicateIndex: null
-            });
-            if (p.onRemoveTag && poppedValue) {
-              p.onRemoveTag(poppedValue);
-            }
+          newCurrentInput = p.backspaceDeletesWord ? '' : poppedValue;
+
+          this.setState({
+            currentInput: newCurrentInput,
+            duplicateIndex: null
+          });
+          if (p.onRemoveTag && poppedValue) {
+            p.onRemoveTag(poppedValue);
           }
         }
         break;
@@ -279,9 +283,11 @@ var TaggedInput = React.createClass({
         }
 
         if (duplicateIndex === -1) {
-          if (p.onBeforeAddTag(trimmedText)) {
-            s.tags.push(trimmedText);
+          if (!p.onBeforeAddTag(trimmedText)) {
+            return;
           }
+
+          s.tags.push(trimmedText);
           self.setState({
             currentInput: '',
             duplicateIndex: null
@@ -301,9 +307,11 @@ var TaggedInput = React.createClass({
           });
         }
       } else {
-        if (p.onBeforeAddTag(trimmedText)) {
-          s.tags.push(trimmedText);
+        if (!p.onBeforeAddTag(trimmedText)) {
+          return;
         }
+
+        s.tags.push(trimmedText);
         self.setState({currentInput: ''}, function () {
           if (p.onAddTag) {
             p.onAddTag(tagText);


### PR DESCRIPTION
Prevent `onAddTag` if `onBeforeAddTag` returns `false`.
This aligns the functionality with the `onRemoveTag` and `onBeforeRemoveTag`

This diff is easier to view with whitespace changes ignored:
https://github.com/tutorialhorizon/react-tagged-input/pull/30/files?w=1

Fix for issue https://github.com/tutorialhorizon/react-tagged-input/issues/25