### PR TITLE
Clone tags array from new props

### DIFF
--- a/dist/TaggedInput.js
+++ b/dist/TaggedInput.js
@@ -137,7 +137,7 @@ var TaggedInput = React.createClass({displayName: "TaggedInput",
 
   componentWillReceiveProps: function (nextProps) {
     this.setState({
-      tags: nextProps.tags
+      tags: (nextProps.tags || []).slice(0)
     })
   },
 

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -137,7 +137,7 @@ var TaggedInput = React.createClass({
 
   componentWillReceiveProps: function (nextProps) {
     this.setState({
-      tags: nextProps.tags
+      tags: (nextProps.tags || []).slice(0)
     })
   },
 


### PR DESCRIPTION
Also slice the tags array when new props are provided.
This was missed in PR https://github.com/tutorialhorizon/react-tagged-input/pull/26

This should fix issue #22