### PR TITLE
Modify onEnter prop to make event useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ current tags and the new tag to be added. The function should return the index o
 
 #### onEnter
 Type: function
+Called any time enter/return key is pressed. The event is passed as the first argument.
 
 #### onAddTag
 Type: function:

--- a/dist/TaggedInput.js
+++ b/dist/TaggedInput.js
@@ -187,12 +187,11 @@ module.exports = React.createClass({
 
     switch (e.keyCode) {
       case KEY_CODES.ENTER:
-        if (s.currentInput) {
-          self._validateAndTag(s.currentInput, function (status) {
-            if (p.onEnter) {
-              p.onEnter(e, s.tags);
-            }
-          });
+        if (p.onEnter) {
+          p.onEnter(e, s.tags);
+        }
+        if (s.currentInput && ! e.isDefaultPrevented()) {
+          self._validateAndTag(s.currentInput);
         }
         break;
     }

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -187,12 +187,11 @@ module.exports = React.createClass({
 
     switch (e.keyCode) {
       case KEY_CODES.ENTER:
-        if (s.currentInput) {
-          self._validateAndTag(s.currentInput, function (status) {
-            if (p.onEnter) {
-              p.onEnter(e, s.tags);
-            }
-          });
+        if (p.onEnter) {
+          p.onEnter(e, s.tags);
+        }
+        if (s.currentInput && ! e.isDefaultPrevented()) {
+          self._validateAndTag(s.currentInput);
         }
         break;
     }


### PR DESCRIPTION
Currently the `onEnter` method is called only when a tag is added and passed an event which isn't available by the time the prop function receives it (this can be fixed with `event.persist()`, but that's still doesn't fix it). So, for example, if in a form I want to prevent the default action on an event there is no way to do it without manually attaching listeners to the input. 

Modified the code so that the `onEnter` method is called any time the `enter/return` key is pressed and passes the actual event, so that `e.preventDefault()` can be used. For the purpose of knowing when the tags are added the developer can still use the `onAddTag` prop.
