### PR TITLE
Avoid uncontrolled / controlled switch

### DIFF
--- a/dist/TaggedInput.js
+++ b/dist/TaggedInput.js
@@ -68,7 +68,7 @@ module.exports = React.createClass({
   getInitialState: function () {
     return {
       tags: (this.props.tags || []).slice(0),
-      currentInput: null
+      currentInput: ''
     };
   },
 

--- a/src/TaggedInput.jsx
+++ b/src/TaggedInput.jsx
@@ -68,7 +68,7 @@ module.exports = React.createClass({
   getInitialState: function () {
     return {
       tags: (this.props.tags || []).slice(0),
-      currentInput: null
+      currentInput: ''
     };
   },
 


### PR DESCRIPTION
This change avoids the appearing of React's warning:

> Warning: [Component] is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.